### PR TITLE
Support for WeeWX 3.7.1+

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,13 @@ environment:
       WEEWX: 3.9.0
       PYTHON: 2.7.17
 
+    - job_name: weewx4-py3.9
+      job_group: build  
+      job_depends_on: initialize
+      PYTHON: 3.9
+      WEEWX_URL: http://www.weewx.com/downloads/development_versions/
+      CODECOVIO_UPLOAD: true
+
     - job_name: initialize
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,16 +31,10 @@ environment:
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
       CODECOVIO_UPLOAD: true
 
-    - job_name: weewx3.7.1-py2.7.17
+    - job_name: weewx3.9.0-py2.7.17
       job_group: build
       job_depends_on: initialize
-      WEEWX: 3.7.1
-      PYTHON: 2.7.17
-
-    - job_name: weewx3.9.2-py2.7.17
-      job_group: build
-      job_depends_on: initialize
-      WEEWX: 3.9.2
+      WEEWX: 3.9.0
       PYTHON: 2.7.17
 
     - job_name: initialize

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,12 @@ environment:
       WEEWX: 3.9.0
       PYTHON: 2.7.17
 
+    - job_name: weewx3.7.0-py2.7.17
+      job_group: build
+      job_depends_on: initialize
+      WEEWX: 3.7.0
+      PYTHON: 2.7.17     
+
     - job_name: weewx4-py3.9
       job_group: build  
       job_depends_on: initialize

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,12 @@ environment:
   # default values
   ENABLED: true
   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
-  PYTHON: 3.6 
+  PYTHON: 3.6.9 
   WEEWX: 4.0.0b18
   WEEWX_URL: http://www.weewx.com/downloads/released_versions/
 
   matrix:
-    - job_name: weewx4-py3
+    - job_name: weewx4-py3.6.9
       job_group: build
       job_depends_on: initialize
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
@@ -18,30 +18,30 @@ environment:
       COVERALLS_UPLOAD: true
       SONAR_UPLOAD: true
 
-    - job_name: weewx4-py3.5
+    - job_name: weewx4-py3.5.9
       job_group: build  
       job_depends_on: initialize
-      PYTHON: 3.5
+      PYTHON: 3.5.9
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
 
-    - job_name: weewx4-py2
+    - job_name: weewx4-py2.7.17
       job_group: build  
       job_depends_on: initialize
-      PYTHON: 2.7
+      PYTHON: 2.7.17
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
       CODECOVIO_UPLOAD: true
 
-    - job_name: weewx3.7.1-py2
+    - job_name: weewx3.7.1-py2.7.17
       job_group: build
       job_depends_on: initialize
       WEEWX: 3.7.1
-      PYTHON: 2.7
+      PYTHON: 2.7.17
 
-    - job_name: weewx3-py2
+    - job_name: weewx3.9.2-py2.7.17
       job_group: build
       job_depends_on: initialize
       WEEWX: 3.9.2
-      PYTHON: 2.7
+      PYTHON: 2.7.17
 
     - job_name: initialize
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,12 @@ environment:
       job_depends_on: initialize
       PYTHON: 3.8
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
-      ENABLED: false
 
     - job_name: weewx4-py3.7.x
       job_group: build  
       job_depends_on: initialize
       PYTHON: 3.7
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
-      ENABLED: false
 
     - job_name: weewx4-py3.6.10
       job_group: build
@@ -31,14 +29,12 @@ environment:
       CODECOVIO_UPLOAD: true
       COVERALLS_UPLOAD: true
       SONAR_UPLOAD: true
-      ENABLED: false
 
     - job_name: weewx4-py3.5.9
       job_group: build  
       job_depends_on: initialize
       PYTHON: 3.5.9
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
-      ENABLED: false
 
     - job_name: weewx4-py2.7.17
       job_group: build  
@@ -52,7 +48,6 @@ environment:
       job_depends_on: initialize
       WEEWX: 3.9.0
       PYTHON: 2.7.17
-      ENABLED: false
 
     - job_name: weewx3.7.1-py2.7.17
       job_group: build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,14 @@ environment:
       job_depends_on: initialize
       PYTHON: 3.8
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
+      ENABLED: false
 
     - job_name: weewx4-py3.7.x
       job_group: build  
       job_depends_on: initialize
       PYTHON: 3.7
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
+      ENABLED: false
 
     - job_name: weewx4-py3.6.10
       job_group: build
@@ -29,12 +31,14 @@ environment:
       CODECOVIO_UPLOAD: true
       COVERALLS_UPLOAD: true
       SONAR_UPLOAD: true
+      ENABLED: false
 
     - job_name: weewx4-py3.5.9
       job_group: build  
       job_depends_on: initialize
       PYTHON: 3.5.9
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
+      ENABLED: false
 
     - job_name: weewx4-py2.7.17
       job_group: build  
@@ -48,6 +52,7 @@ environment:
       job_depends_on: initialize
       WEEWX: 3.9.0
       PYTHON: 2.7.17
+      ENABLED: false
 
     - job_name: weewx3.7.1-py2.7.17
       job_group: build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,12 @@ environment:
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
       CODECOVIO_UPLOAD: true
 
+    - job_name: weewx3.7.1-py2
+      job_group: build
+      job_depends_on: initialize
+      WEEWX: 3.7.1
+      PYTHON: 2.7
+
     - job_name: weewx3-py2
       job_group: build
       job_depends_on: initialize

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,12 @@ environment:
   # default values
   ENABLED: true
   APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
-  PYTHON: 3.6.9 
+  PYTHON: 3.6.10
   WEEWX: 4.0.0b18
   WEEWX_URL: http://www.weewx.com/downloads/released_versions/
 
   matrix:
-    - job_name: weewx4-py3.6.9
+    - job_name: weewx4-py3.6.10
       job_group: build
       job_depends_on: initialize
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,10 +49,10 @@ environment:
       WEEWX: 3.9.0
       PYTHON: 2.7.17
 
-    - job_name: weewx3.7.0-py2.7.17
+    - job_name: weewx3.7.1-py2.7.17
       job_group: build
       job_depends_on: initialize
-      WEEWX: 3.7.0
+      WEEWX: 3.7.1
       PYTHON: 2.7.17     
 
     - job_name: weewx4-py3.9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,18 @@ environment:
   WEEWX_URL: http://www.weewx.com/downloads/released_versions/
 
   matrix:
+    - job_name: weewx4-py3.8.x
+      job_group: build  
+      job_depends_on: initialize
+      PYTHON: 3.8
+      WEEWX_URL: http://www.weewx.com/downloads/development_versions/
+
+    - job_name: weewx4-py3.7.x
+      job_group: build  
+      job_depends_on: initialize
+      PYTHON: 3.7
+      WEEWX_URL: http://www.weewx.com/downloads/development_versions/
+
     - job_name: weewx4-py3.6.10
       job_group: build
       job_depends_on: initialize
@@ -42,7 +54,6 @@ environment:
       job_depends_on: initialize
       PYTHON: 3.9
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/
-      CODECOVIO_UPLOAD: true
 
     - job_name: initialize
       WEEWX_URL: http://www.weewx.com/downloads/development_versions/

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -6,4 +6,11 @@ PYTHONPATH=./weewx/bin pylint ./bin/user/MQTTSubscribe.py -r n --msg-template="{
 rc=${PIPESTATUS[0]}
 detail=`cat pylint.txt`
 
-appveyor AddMessage "pylint $WEEWX $PYTHON: $rc" -Details "$detail"
+if [ $rc eq 0 ]; then
+  category="Information"
+if [ $rc gt 2 ]; then
+  category="Warning"
+else
+  category="Error"
+
+appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc" -Category $category -Details "$detail"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -3,3 +3,6 @@ if [ "$ENABLED" != "true" ]; then
 fi
 
 PYTHONPATH=./weewx/bin pylint ./bin/user/MQTTSubscribe.py -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee pylint.txt
+rc = $?
+
+appveyor AddMessage "test $rc" -Details `cat pylint.txt`

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -6,9 +6,9 @@ PYTHONPATH=./weewx/bin pylint ./bin/user/MQTTSubscribe.py -r n --msg-template="{
 rc=${PIPESTATUS[0]}
 detail=`cat pylint.txt`
 
-if [ $rc eq 0 ]; then
+if [ $rc -eq 0 ]; then
   category="Information"
-if [ $rc gt 2 ]; then
+if [ $rc -gt 2 ]; then
   category="Warning"
 else
   category="Error"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -14,4 +14,4 @@ else
   category="Error"
 fi
 
-appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc" -Category $category -Details "$detail"
+appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc $category" -Details "$detail"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -3,7 +3,7 @@ if [ "$ENABLED" != "true" ]; then
 fi
 
 PYTHONPATH=./weewx/bin pylint ./bin/user/MQTTSubscribe.py -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee pylint.txt
-rc=$?
+rc=${PIPESTATUS[0]}
 detail=`cat pylint.txt`
 
-appveyor AddMessage "test $rc" -Details "$detail"
+appveyor AddMessage "pylint $WEEWX $PYTHON: $rc" -Details "$detail"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -8,7 +8,7 @@ detail=`cat pylint.txt`
 
 if [ $rc -eq 0 ]; then
   category="Information"
-if [ $rc -gt 2 ]; then
+elif [ $rc -gt 2 ]; then
   category="Warning"
 else
   category="Error"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -14,4 +14,4 @@ else
   category="Error"
 fi
 
-appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc $category" -Details "$detail"
+appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc " -Category $category -Details "$detail"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -3,6 +3,7 @@ if [ "$ENABLED" != "true" ]; then
 fi
 
 PYTHONPATH=./weewx/bin pylint ./bin/user/MQTTSubscribe.py -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee pylint.txt
-rc = $?
+rc=$?
+detail=`cat pylint.txt`
 
-appveyor AddMessage "test $rc" -Details `cat pylint.txt`
+appveyor AddMessage "test $rc" -Details "$detail"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -12,5 +12,6 @@ if [ $rc gt 2 ]; then
   category="Warning"
 else
   category="Error"
+fi
 
 appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc" -Category $category -Details "$detail"

--- a/appveyor/build_script.sh
+++ b/appveyor/build_script.sh
@@ -8,10 +8,15 @@ detail=`cat pylint.txt`
 
 if [ $rc -eq 0 ]; then
   category="Information"
+  build_rc=0
 elif [ $rc -gt 2 ]; then
   category="Warning"
+  build_rc=0
 else
   category="Error"
+  build_rc=1
 fi
 
 appveyor AddMessage "pylint weewx=$WEEWX python=$PYTHON rc=$rc " -Category $category -Details "$detail"
+
+exit $build_rc

--- a/appveyor/install.sh
+++ b/appveyor/install.sh
@@ -3,9 +3,11 @@
       exit 0
     fi
 
-    echo "Running sonar runner install"
-    curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
-    unzip -qq -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+.   if [ "$SONAR_UPLOAD" = "true" ]; then
+      echo "Running sonar runner install"
+      curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
+      unzip -qq -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+    fi
 
     echo "Running mosquitto install"
     sudo apt-get -qq --assume-yes install mosquitto

--- a/appveyor/install.sh
+++ b/appveyor/install.sh
@@ -3,7 +3,7 @@
       exit 0
     fi
 
-.   if [ "$SONAR_UPLOAD" = "true" ]; then
+    if [ "$SONAR_UPLOAD" = "true" ]; then
       echo "Running sonar runner install"
       curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
       unzip -qq -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/

--- a/bin/user/MQTTSubscribe.py
+++ b/bin/user/MQTTSubscribe.py
@@ -284,7 +284,7 @@ except ImportError: # pragma: no cover
             if self.console:
                 print('%s: %s' % (__name__, msg))
 
-VERSION = '1.5.3-rc02'
+VERSION = '1.5.3-rc03'
 DRIVER_NAME = 'MQTTSubscribeDriver'
 DRIVER_VERSION = VERSION
 

--- a/bin/user/MQTTSubscribe.py
+++ b/bin/user/MQTTSubscribe.py
@@ -219,7 +219,7 @@ try: # pragma: no cover
         if logging_level:
             weewx.debug = logging_level
 
-        weeutil.logger.setup('wee_MQTTSS', {})
+        weeutil.logger.setup('wee_MQTTSS', {}) # weewx3 false positive, code never reached pylint: disable=no-member
 
         log = logging.getLogger(__name__)
         # ToDo - setup customized logger

--- a/bin/user/MQTTSubscribe.py
+++ b/bin/user/MQTTSubscribe.py
@@ -1167,6 +1167,10 @@ if __name__ == '__main__': # pragma: no cover
     import argparse
     import os
     from weewx.engine import StdEngine # pylint: disable=ungrouped-imports
+    try:
+        from weeutil.config import merge_config
+    except ImportError:
+        from weecfg import merge_config # pre WeeWX 3.9
 
     USAGE = """MQTTSubscribeService --help
                CONFIG_FILE
@@ -1263,8 +1267,7 @@ if __name__ == '__main__': # pragma: no cover
         weewx.accum.initialize(config_dict)
 
         # override the configured binding with the parameter value
-        weeutil.config.merge_config(config_dict,
-                                    {'MQTTSubscribeService': {'binding': binding}})
+        merge_config(config_dict, {'MQTTSubscribeService': {'binding': binding}})
 
         config_console(config_dict, options.console)
 
@@ -1294,34 +1297,26 @@ if __name__ == '__main__': # pragma: no cover
             if 'MQTTSubscribeDriver' in config_dict and 'topics' in config_dict['MQTTSubscribeDriver']:
                 config_dict['MQTTSubscribeDriver']['topics'] = {}
             for topic in topics:
-                weeutil.config.merge_config(config_dict,
-                                            {'MQTTSubscribeService': {'topics': {topic:{}}}})
-                weeutil.config.merge_config(config_dict,
-                                            {'MQTTSubscribeDriver': {'topics': {topic:{}}}})
+                merge_config(config_dict, {'MQTTSubscribeService': {'topics': {topic:{}}}})
+                merge_config(config_dict, {'MQTTSubscribeDriver': {'topics': {topic:{}}}})
 
     def config_host(config_dict, host_option):
         """ Configure the host. """
         if host_option:
-            weeutil.config.merge_config(config_dict,
-                                        {'MQTTSubscribeService': {'host': host_option}})
-            weeutil.config.merge_config(config_dict,
-                                        {'MQTTSubscribeDriver': {'host': host_option}})
+            merge_config(config_dict, {'MQTTSubscribeService': {'host': host_option}})
+            merge_config(config_dict, {'MQTTSubscribeDriver': {'host': host_option}})
 
     def config_callback(config_dict, callback_option):
         """ Configure the callback. """
         if callback_option:
-            weeutil.config.merge_config(config_dict,
-                                        {'MQTTSubscribeService': {'message_callback': {'type': callback_option}}})
-            weeutil.config.merge_config(config_dict,
-                                        {'MQTTSubscribeDriver': {'message_callback': {'type': callback_option}}})
+            merge_config(config_dict, {'MQTTSubscribeService': {'message_callback': {'type': callback_option}}})
+            merge_config(config_dict, {'MQTTSubscribeDriver': {'message_callback': {'type': callback_option}}})
 
     def config_console(config_dict, console_option):
         """ If specified, override the console logging. """
         if console_option:
-            weeutil.config.merge_config(config_dict,
-                                        {'MQTTSubscribeService': {'console': True}})
-            weeutil.config.merge_config(config_dict,
-                                        {'MQTTSubscribeDriver': {'console': True}})
+            merge_config(config_dict, {'MQTTSubscribeService': {'console': True}})
+            merge_config(config_dict, {'MQTTSubscribeDriver': {'console': True}})
 
     def simulate_driver_archive(driver, record_count, interval, delay):
         """ Simulate running MQTTSubscribe as a driver that generates archive records. """

--- a/bin/user/tests/func/utils.py
+++ b/bin/user/tests/func/utils.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=fixme
+from __future__ import print_function
 
 import json
 import sys

--- a/bin/user/tests/unit/test_weewx_stubs.py
+++ b/bin/user/tests/unit/test_weewx_stubs.py
@@ -1,11 +1,14 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
+# pylint: disable=too-few-public-methods
+from __future__ import print_function
+
 import locale
 import sys
 import time
 
-class weewx: # pylint: disable=invalid-name
-    class units:
+class weewx(object): # pylint: disable=invalid-name
+    class units(object):
         METRIC = 0x10
         METRICWX = 0x11
         US = 0x01
@@ -19,7 +22,7 @@ class weewx: # pylint: disable=invalid-name
         def to_std_system(self):
             pass
 
-    class accum:
+    class accum(object):
         def Accum(self):
             pass
 
@@ -29,20 +32,20 @@ class weewx: # pylint: disable=invalid-name
     class NEW_LOOP_PACKET(object):
         """Event issued when a new LOOP packet is available. The event contains
         attribute 'packet', which is the new LOOP packet."""
-    class engine:
+    class engine(object):
         class StdService(object):
             def __init__(self, engine, config_dict):
                 pass
             def bind(self, p1, p2):
                 pass
-    class drivers: # pylint: disable=invalid-name
-        class AbstractDevice:
+    class drivers(object): # pylint: disable=invalid-name
+        class AbstractDevice(object):
             pass
-        class AbstractConfEditor:
+        class AbstractConfEditor(object):
             pass
 
-class weeutil:
-    class weeutil():
+class weeutil(object):
+    class weeutil(object):
         class TimeSpan(tuple):
             """Represents a time span, exclusive on the left, inclusive on the right."""
 

--- a/install.py
+++ b/install.py
@@ -28,7 +28,7 @@ if PY2:
 else:
     from io import StringIO
 
-VERSION = '1.5.3-rc02'
+VERSION = '1.5.3-rc03'
 
 MQTTSUBSCRIBESERVICE_CONFIG = """
 [MQTTSubscribeService]

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,16 @@
-PYTHONPATH=bin:../weewx/bin pylint ./*.py
-PYTHONPATH=bin:../weewx/bin pylint ./bin/user
-PYTHONPATH=bin:../weewx/bin pylint ./bin/user/tests/unit/*.py -d duplicate-code
-PYTHONPATH=bin:../weewx/bin pylint ./bin/user/tests/func/*.py -d duplicate-code
+#! /bin/bash
+if [ -z "$1" ]
+then
+    WEEWX=weewx4
+else
+    WEEWX=$1
+fi
+
+# Note, the value for $WEEWX can be relative. For example ../weewx-source/weewx-3.7.1
+
+echo "Running python $PYENV_VERSION weewx $WEEWX"
+
+PYTHONPATH=bin:../$WEEWX/bin python -m pylint ./*.py
+PYTHONPATH=bin:../$WEEWX/bin python -m pylint ./bin/user
+PYTHONPATH=bin:../$WEEWX/bin python -m pylint ./bin/user/tests/unit/*.py -d duplicate-code
+PYTHONPATH=bin:../$WEEWX/bin python -m pylint ./bin/user/tests/func/*.py -d duplicate-code

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+if [ -z "$1" ]
+then
+    WEEWX=weewx4
+else
+    WEEWX=$1
+fi
+
+# Note, the value for $WEEWX can be relative. For example ../weewx-source/weewx-3.7.1
+
+echo "Running python $PYENV_VERSION weewx $WEEWX"
+PYTHONPATH=bin:../$WEEWX/bin python -m unittest discover bin/user/tests/unit
+
+PYTHONPATH=bin:../$WEEWX/bin python -m unittest discover bin/user/tests/func
+
+echo "Completed python $PYENV_VERSION weewx $WEEWX"


### PR DESCRIPTION
Use merge_config from weecfg if not found in weeutil.config

Improved linting
- support multiple versions of WeeWX and Python when running locally
- put linting messages into AppVeyor messages (easier to find)

Lint cleanup of tests